### PR TITLE
Merge game information types and actor messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ project/plugins/project/
 
 # MacOS specific
 .DS_Store
+
+# vim specific
+*.swp

--- a/src/main/scala/yokohama/holdem/Messages.scala
+++ b/src/main/scala/yokohama/holdem/Messages.scala
@@ -1,0 +1,38 @@
+package yokohama.holdem
+
+import yokohama.holdem.types._
+import yokohama.holdem.Cards.Card
+
+trait GameToPlayerMessages {
+  /* Game management messages */
+  case class StartGame(status: GameInfo)
+  case class EndGame(summary: GameInfo)
+  // send types.StatusInfo when receiving PlayerToGameMessages.StatusRequest
+
+  /* Generic messages per round */
+  case class StartRound(status: RoundInfo)
+  case class StopRound(summary: RoundInfo)
+
+  /* Round action messages */
+  case class Deal(hand: (Card, Card), status: GameInfo)
+  case class NextMove(minBet: Double, maxBet: Double, s: RoundInfo, timeout: Int, retriesLeft: Int)
+  case class UpdatePurse(amount: Double)
+  // send types.CommunityCards to signify dealer giving the next turn
+}
+
+object GameToPlayerMessages extends GameToPlayerMessages
+
+trait PlayerToGameMessages {
+  /* Game management messages */
+  case object StatusRequest
+  case object OK
+  case object LeaveGame
+
+  /* Round action messages */
+  case class  Bet(amount: Double)
+  case object Call
+  case object AllIn
+  case object Fold
+}
+object PlayerToGameMessages extends PlayerToGameMessages
+

--- a/src/main/scala/yokohama/holdem/types/StatusTypes.scala
+++ b/src/main/scala/yokohama/holdem/types/StatusTypes.scala
@@ -1,0 +1,29 @@
+package yokohama.holdem.types
+
+import yokohama.holdem.Cards.Card
+
+case class PlayerInfo(id: String, name: String, purse: Double)
+
+case class CommunityCards(flop: Option[(Card, Card, Card)], turn: Option[Card], river: Option[Card])
+
+trait StatusInfo {
+  val msg: Option[String]
+}
+
+case class GameInfo(
+  uuid: java.util.UUID,
+  players: List[PlayerInfo], // Ordered list according to position
+  roundInfo: Option[RoundInfo],
+  msg: Option[String] = None) extends StatusInfo
+
+case class RoundInfo(
+  num: Int,
+  dealer: PlayerInfo,
+  smallBlind: PlayerInfo,
+  bigBlind: PlayerInfo,
+  currentlyBetting: Option[PlayerInfo],
+  bets: List[PlayerInfo],
+  cc: CommunityCards,
+  pot: Double,
+  msg: Option[String] = None) extends StatusInfo
+


### PR DESCRIPTION
This update includes:

- Game and player messages as detailed in wiki page, 
- Basic `PlayerInfo`, `GameInfo`, and `RoundInfo` types (subject to further improvement), and
- A case class for `CommunityCards`.

I would also suggest that we add the following method in the CardEvaluation module:
```scala
def getBestHand(hand: (Card, Card), cc: CommunityCards): Cards.BestHand
```
that would trivially produce a `FullHand` and then passed on evaluate to get the `BestHand` possible.